### PR TITLE
Fixing efficiency symbol and adding units

### DIFF
--- a/src/main/io/displayport_msp_dji_compat.c
+++ b/src/main/io/displayport_msp_dji_compat.c
@@ -136,31 +136,37 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_DECORATION + 7: // NW pointing arrow
             return DJI_SYM_ARROW_11;
-
+/*
+        case SYM_VTX_POWER:
+            return DJI_SYM_VTX_POWER;
+*/
         case SYM_VOLT:
             return DJI_SYM_VOLT;
 
         case SYM_MAH:
             return DJI_SYM_MAH;
 
+        case SYM_AH_MI:
+            return DJI_SYM_MI;
+
+        case SYM_AH_NM:
+            return DJI_SYM_MI;
+
         case SYM_AH_KM:
             return DJI_SYM_KM;
 
-        case SYM_AH_MI:
-            return DJI_SYM_MI;
-/*
-        case SYM_VTX_POWER:
-            return DJI_SYM_VTX_POWER;
+        case SYM_MAH_MI_0:
+            return DJI_SYM_MAH;
 
-        case SYM_AH_NM:
-            return DJI_SYM_AH_NM;
+        case SYM_MAH_MI_1:
+            return DJI_SYM_MI;
 
         case SYM_MAH_NM_0:
-            return DJI_SYM_MAH_NM_0;
+            return DJI_SYM_MAH;
 
         case SYM_MAH_NM_1:
-            return DJI_SYM_MAH_NM_1;
-*/
+            return DJI_SYM_MI;
+
         case SYM_MAH_KM_0:
             return DJI_SYM_MAH;
 
@@ -193,7 +199,16 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_AMP:
             return DJI_SYM_AMP;
+
+        case SYM_WATT:
+            return DJI_SYM_WATT;
 /*
+        case SYM_MW:
+            return DJI_SYM_MW;
+
+        case SYM_KILOWATT:
+            return DJI_SYM_KILOWATT;
+
         case SYM_WH:
             return DJI_SYM_WH;
 
@@ -205,15 +220,6 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 
         case SYM_WH_NM:
             return DJI_SYM_WH_NM;
-*/
-        case SYM_WATT:
-            return DJI_SYM_WATT;
-/*
-        case SYM_MW:
-            return DJI_SYM_MW;
-
-        case SYM_KILOWATT:
-            return DJI_SYM_KILOWATT;
 */
         case SYM_FT:
             return DJI_SYM_FT;
@@ -298,12 +304,6 @@ uint8_t getDJICharacter(uint8_t ch, uint8_t page)
 /*
         case SYM_KT:
             return DJI_SYM_KT
-
-        case SYM_MAH_MI_0:
-            return DJI_SYM_MAH_MI_0;
-
-        case SYM_MAH_MI_1:
-            return DJI_SYM_MAH_MI_1;
 */
         case SYM_THR:
             return DJI_SYM_THR;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -3401,29 +3401,31 @@ static bool osdDrawSingleElement(uint8_t item)
                 case OSD_UNIT_IMPERIAL:
                     moreThanAh = osdFormatCentiNumber(buff, value * METERS_PER_MILE / 10, 1000, 0, 2, digits, false);
                     if (!moreThanAh) {
-                        tfp_sprintf(buff + strlen(buff), "%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                        tfp_sprintf(buff + strlen(buff), "%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                     } else {
                         tfp_sprintf(buff + strlen(buff), "%c", SYM_AH_MI);
                     }
                     if (!efficiencyValid) {
                         buff[0] = buff[1] = buff[2] = buff[3] = '-';
                         buff[digits] = SYM_MAH_MI_0;        // This will overwrite the "-" at buff[3] if not in DJICOMPAT mode
-                        buff[digits + 1] = SYM_MAH_MI_1;
-                        buff[digits + 2] = '\0';
+                        buff[digits + 1] = '/'
+                        buff[digits + 2] = SYM_MAH_MI_1;
+                        buff[digits + 3] = '\0';
                     }
                     break;
                 case OSD_UNIT_GA:
                      moreThanAh = osdFormatCentiNumber(buff, value * METERS_PER_NAUTICALMILE / 10, 1000, 0, 2, digits, false);
                     if (!moreThanAh) {
-                        tfp_sprintf(buff + strlen(buff), "%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                        tfp_sprintf(buff + strlen(buff), "%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                     } else {
                         tfp_sprintf(buff + strlen(buff), "%c", SYM_AH_NM);
                     }
                     if (!efficiencyValid) {
                         buff[0] = buff[1] = buff[2] = buff[3] = '-';
                         buff[digits] = SYM_MAH_NM_0;
-                        buff[digits + 1] = SYM_MAH_NM_1;
-                        buff[digits + 2] = '\0';
+                        buff[digits + 1] = '/';
+                        buff[digits + 2] = SYM_MAH_NM_1;
+                        buff[digits + 3] = '\0';
                     }
                     break;
                 case OSD_UNIT_METRIC_MPH:
@@ -3431,15 +3433,16 @@ static bool osdDrawSingleElement(uint8_t item)
                 case OSD_UNIT_METRIC:
                     moreThanAh = osdFormatCentiNumber(buff, value * 100, 1000, 0, 2, digits, false);
                     if (!moreThanAh) {
-                        tfp_sprintf(buff + strlen(buff), "%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                        tfp_sprintf(buff + strlen(buff), "%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
                     } else {
                         tfp_sprintf(buff + strlen(buff), "%c", SYM_AH_KM);
                     }
                     if (!efficiencyValid) {
                         buff[0] = buff[1] = buff[2] = buff[3] = '-';
                         buff[digits] = SYM_MAH_KM_0;
-                        buff[digits + 1] = SYM_MAH_KM_1;
-                        buff[digits + 2] = '\0';
+                        buff[digits + 1] = '/';
+                        buff[digits + 2] = SYM_MAH_KM_1;
+                        buff[digits + 3] = '\0';
                     }
                     break;
             }
@@ -4960,7 +4963,7 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                         if (osdDisplayIsHD()) {
                             if (!moreThanAh)
-                                tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                                tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                             else
                                 tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_MI);
 
@@ -4972,11 +4975,11 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
 
                         if (!moreThanAh)
-                            tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                            tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                         else
                             tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_MI);
                     } else {
-                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
+                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c/%c", SYM_MAH_MI_0, SYM_MAH_MI_1);
                     }
                 } else {
                     if (efficiencyValid) {
@@ -4998,7 +5001,7 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                          if (osdDisplayIsHD()) {
                             if (!moreThanAh)
-                                tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                                tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                             else
                                 tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_NM);
 
@@ -5009,12 +5012,12 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                         moreThanAh = moreThanAh || osdFormatCentiNumber(buff, (int32_t)(getMAhDrawn() * 10000.0f * METERS_PER_NAUTICALMILE / totalDistance), 1000, 0, 2, digits, false);
                         strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                         if (!moreThanAh) {
-                            tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                            tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                         } else {
                             tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_NM);
                         }
                     } else {
-                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
+                        tfp_sprintf(outBuff + strlen(outBuff), "---/---%c/%c", SYM_MAH_NM_0, SYM_MAH_NM_1);
                     }
                 } else {
                     if (efficiencyValid) {
@@ -5043,7 +5046,7 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                 strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                 if (osdDisplayIsHD()) {
                     if (!moreThanAh)
-                        tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                        tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
                     else
                         tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_KM);
 
@@ -5054,12 +5057,12 @@ uint8_t drawStat_AverageEfficiency(uint8_t col, uint8_t row, uint8_t statValX, b
                 moreThanAh = moreThanAh || osdFormatCentiNumber(buff, (int32_t)(getMAhDrawn() * 10000000.0f / totalDistance), 1000, 0, 2, digits, false);
                 strcat(outBuff, osdFormatTrimWhiteSpace(buff));
                 if (!moreThanAh) {
-                    tfp_sprintf(outBuff + strlen(outBuff), "%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                    tfp_sprintf(outBuff + strlen(outBuff), "%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
                 } else {
                     tfp_sprintf(outBuff + strlen(outBuff), "%c", SYM_AH_KM);
                 }
             } else {
-                tfp_sprintf(outBuff + strlen(outBuff), "---/---%c%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
+                tfp_sprintf(outBuff + strlen(outBuff), "---/---%c/%c", SYM_MAH_KM_0, SYM_MAH_KM_1);
             }
         } else {
             if (efficiencyValid) {


### PR DESCRIPTION
In the regular version of the firmware, the efficiency symbol is made of two parts where the division is made with a horizontal line, 

A good example of this is the `mAh/km` symbol. 

Betaflight does not support those newer symbols and so I adapted to code to add a `/` between the `mAh` and the `km` symbol the same way that it is in Betaflight. 

The same was done for imperial units. 

Important to note that if Nautical Miles are selected, the symbol still remains as `mi` and the user has to know that nautical miles and not regular miles are used. 